### PR TITLE
Label links to other notebooks as "Chapter" rather than "Section".

### DIFF
--- a/bookbook/filter_links.py
+++ b/bookbook/filter_links.py
@@ -13,7 +13,7 @@ def convert_link(key, val, fmt, meta):
         # Links to other notebooks
         m = re.match(r'(\d+\-.+)\.ipynb$', target)
         if m:
-            return RawInline('tex', 'Section \\ref{sec:%s}' % m.group(1))
+            return RawInline('tex', 'Chapter \\ref{sec:%s}' % m.group(1))
             
         # Links to sections of this or other notebooks
         m = re.match(r'(\d+\-.+\.ipynb)?#(.+)$', target)

--- a/tests/test_latex.py
+++ b/tests/test_latex.py
@@ -35,7 +35,7 @@ def test_convert_link():
 def test_exporter_converts_links():
     out, res = latex.MyLatexExporter().from_filename(
                     str(sample_dir / '01-introduction.ipynb'))
-    assert 'Section \\ref{sec:02-in-which-we}' in out
+    assert 'Chapter \\ref{sec:02-in-which-we}' in out
     assert 'Section \\ref{just-a-subheading}' in out
 
 


### PR DESCRIPTION
Perhaps this should be a configurable option.