### PR TITLE
WIP: add toc2 as template to generate html files

### DIFF
--- a/bookbook/html.py
+++ b/bookbook/html.py
@@ -11,6 +11,8 @@ from nbconvert.writers import FilesWriter
 from nbconvert.filters.markdown_mistune import MarkdownWithMath, IPythonRenderer
 from jinja2 import Environment, FileSystemLoader
 
+from traitlets.config import Config
+
 _PKGDIR = Path(__file__).parent
 log = logging.getLogger(__name__)
 
@@ -29,6 +31,21 @@ class MyHTMLExporter(HTMLExporter):
     def default_filters(self):
         yield from super().default_filters()
         yield ('markdown2html', markdown2html_custom)
+    def _template_file_default(self):
+        return 'toc2'
+    @property
+    def default_config(self):
+        c = Config()
+        #  import here to avoid circular import
+        from jupyter_contrib_nbextensions.nbconvert_support import (
+            templates_directory)
+        c.merge(super(MyHTMLExporter, self).default_config)
+
+        c.TemplateExporter.template_path = [
+            '.',
+            templates_directory(),
+        ]
+        return c
 
 class IndexEntry:
     def __init__(self, chapter_no, title, filename):


### PR DESCRIPTION
See https://github.com/ipython-contrib/jupyter_contrib_nbextensions/issues/1245 for context.

I believe that the html generator template file could be added as option to the CLI tool, but before I do that I'd like to have your opinion on the general approach here. Is there an easier way to reach the same goal? 